### PR TITLE
Configure CDN by config to allow NonHTTP app-usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ ember-cli-sentry expects to find a `sentry` key in _ENV_.
 var ENV = {
   /* rest of the conf */
   sentry: {
+    cdn: '//cdn.ravenjs.com',
     dsn: 'https://dsn_key@app.getsentry.com/app_id',
     version: '1.1.16',
     whitelistUrls: [ 'localhost:4200', 'site.local' ]

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
 
   contentFor: function(type, config){
     if (type === 'body') {
-      return '<script src="//cdn.ravenjs.com/' + config.sentry.version + '/jquery,native/raven.min.js"></script>';
+      return '<script src="' + config.sentry.cdn + '/' + config.sentry.version + '/jquery,native/raven.min.js"></script>';
     }
   }
 


### PR DESCRIPTION
We're having issues with this in our app-deploy, as it's using the file: protocol and not http/https.
Using the below we are able to define the CDN to pick from, without the prefixed // leading to the file: protocol!