### PR TITLE
Add option to skip CDN loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ ember-cli-sentry expects to find a `sentry` key in _ENV_.
 var ENV = {
   /* rest of the conf */
   sentry: {
+    skipCdn: false, // skip loading from cdn
+    cdn: '//cdn.ravenjs.com',
     dsn: 'https://dsn_key@app.getsentry.com/app_id',
     version: '1.1.16',
     whitelistUrls: [ 'localhost:4200', 'site.local' ]

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ module.exports = {
   name: 'ember-cli-sentry',
 
   contentFor: function(type, config){
-    if (type === 'body') {
-      return '<script src="//cdn.ravenjs.com/' + config.sentry.version + '/jquery,native/raven.min.js"></script>';
+    if (type === 'body' && !config.sentry.skipCdn) {
+      return '<script src="' + config.sentry.cdn + '/' + config.sentry.version + '/jquery,native/raven.min.js"></script>';
     }
   }
 


### PR DESCRIPTION
We have an "offline" packaged app with status-checking of offline-mode, loading resources from CDN breaks. Therefore we load Raven separately in Bower.

Might be useful for others!