### PR TITLE
Support release parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ var ENV = {
     dsn: 'https://dsn_key@app.getsentry.com/app_id',
     version: '1.1.16',
     whitelistUrls: [ 'localhost:4200', 'site.local' ],
+    release: 'd931e759f47267da6e0a65b18ce9e403fc93dab8', // Pass release-parameter to Sentry
     development: false // Set to true, to disable while developing
   }
 }

--- a/app/initializers/raven-setup.js
+++ b/app/initializers/raven-setup.js
@@ -12,7 +12,8 @@ export function initialize() {
   var _onerror;
 
   Raven.config(config.sentry.dsn, {
-    whitelistUrls: config.sentry.whitelistUrls
+    whitelistUrls: config.sentry.whitelistUrls,
+    release: config.sentry.release
   }).install();
 
   _onerror = Ember.onerror;


### PR DESCRIPTION
Sentry has just adopted and support a release parameter in their API.
This patch makes it possible to pass down this parameter through the config.

https://gist.github.com/dcramer/619d53dabfbc2ed008a1
https://github.com/getsentry/raven-js/commit/8363af8c230a540ea14da62877bc3119ff614ff7