### PR TITLE
Update depreciated RSVP.onerror to RSVP.on 

### DIFF
--- a/app/initializers/raven-setup.js
+++ b/app/initializers/raven-setup.js
@@ -23,8 +23,10 @@ export function initialize() {
     }
   }
 
-  Ember.RSVP.configure('onerror', function(error){
-    Raven.captureException(error);
+  Ember.RSVP.on('error', function(error){
+    if(error !== undefined){
+      Raven.captureException(error);
+    }
   });
 }
 


### PR DESCRIPTION
Per the RSVP.js documentation (https://github.com/tildeio/rsvp.js#error-handling), RSVP.onerror has been depreciated in favor of RSVP.on.  Additionally, this pull request ignores false positives by ignoring callbacks with an undefined error.