### PR TITLE
Use the Ember plugin for Raven.

### DIFF
--- a/app/initializers/raven-setup.js
+++ b/app/initializers/raven-setup.js
@@ -15,20 +15,6 @@ export function initialize() {
     release: config.APP.version,
     whitelistUrls: config.sentry.whitelistUrls
   }).install();
-
-  _onerror = Ember.onerror;
-  Ember.onerror = function(error){
-    Raven.captureException(error);
-    if (typeof _onerror === 'function') {
-      _onerror.call(this, error);
-    }
-  }
-
-  Ember.RSVP.on('error', function(error){
-    if(error !== undefined){
-      Raven.captureException(error);
-    }
-  });
 }
 
 export default {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
   name: 'ember-cli-sentry',
 
   contentFor: function(type, config){
-    if (type === 'body' && !config.sentry.skipCdn) {
+    if (type === 'body-footer' && !config.sentry.skipCdn) {
       return '<script src="' + config.sentry.cdn + '/' + config.sentry.version + '/ember,jquery,native/raven.min.js"></script>';
     }
   }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
 
   contentFor: function(type, config){
     if (type === 'body' && !config.sentry.skipCdn) {
-      return '<script src="' + config.sentry.cdn + '/' + config.sentry.version + '/jquery,native/raven.min.js"></script>';
+      return '<script src="' + config.sentry.cdn + '/' + config.sentry.version + '/ember,jquery,native/raven.min.js"></script>';
     }
   }
 


### PR DESCRIPTION
The implementation is roughly similar, but it makes sense to me to use the
shared version of the Ember plugin (this way all ember-cli-sentry users
benefit from fixes upstream).

Current plugin link:

https://github.com/getsentry/raven-js/blob/d3e70256b6d1dfcfd20ddae89d0d7acd3403b579/plugins/ember.js