### PR TITLE
Add option to pass dataCallback from the ember config

### DIFF
--- a/app/initializers/raven-setup.js
+++ b/app/initializers/raven-setup.js
@@ -14,10 +14,17 @@ export function initialize() {
     throw new Error('`sentry` should be configured when not in development mode.');
   }
 
-  Raven.config(config.sentry.dsn, {
-    release: config.APP.version,
-    whitelistUrls: config.sentry.whitelistUrls
-  }).install();
+  var options = {};
+
+  options.whitelistUrls = config.sentry.whitelistUrls;
+
+  options.release = config.APP.version;
+
+  if (typeof config.sentry.dataCallback === 'function') {
+    options.dataCallback = config.sentry.dataCallback;
+  }
+
+  Raven.config(config.sentry.dsn, options).install();
 }
 
 export default {


### PR DESCRIPTION
This enables you to modify the stack-payload before passing it to Sentry.

Work in progress - cant verify success yet.