### PR TITLE
Allow specifying sentry release on the service

### DIFF
--- a/app/instance-initializers/raven-setup.js
+++ b/app/instance-initializers/raven-setup.js
@@ -15,8 +15,13 @@ export function initialize(application) {
     dsn,
     debug = true,
     includePaths = [],
-    whitelistUrls = []
+    whitelistUrls = [],
+    serviceName = 'logger',
+    serviceReleaseProperty = 'release'
   } = config.sentry;
+
+  const lookupName = `service:${serviceName}`;
+  const service = application.container.lookup(lookupName);
 
   try {
     window.Raven.debug = debug;
@@ -24,7 +29,7 @@ export function initialize(application) {
     window.Raven.config(dsn, {
       includePaths,
       whitelistUrls,
-      release: config.APP.version
+      release: service.get(serviceReleaseProperty) || config.APP.version
     });
   } catch (e) {
     return;
@@ -35,9 +40,7 @@ export function initialize(application) {
   const { globalErrorCatching = true } = config.sentry;
 
   if (globalErrorCatching === true) {
-    const { serviceName = 'logger' } = config.sentry;
-    const lookupName = `service:${serviceName}`;
-    application.container.lookup(lookupName).enableGlobalErrorCatching();
+    service.enableGlobalErrorCatching();
   }
 }
 


### PR DESCRIPTION
Hey Damien,

this is basically the only change I need in order to make `ember-cli-deploy-sentry` work really nice with your addon.

If you don't like the coupling to the DOM in the instance-initializer, we could possibly also read this from the logger service and I would implement it there.

Just let me know, what you prefer...

Best regards, 
Domme