### PR TITLE
Initializer fixup for Ember 2.1

### DIFF
--- a/app/initializers/raven.js
+++ b/app/initializers/raven.js
@@ -1,6 +1,7 @@
 import config from '../config/environment';
 
-export function initialize(container, application) {
+export function initialize() {
+  const application = arguments[1] || arguments[0];
   const { serviceName = 'logger' } = config.sentry;
   const lookupName = `service:${serviceName}`;
   const { exposedPropertyName = 'logger' } = config.sentry;


### PR DESCRIPTION
Fix 

```
DEPRECATION: The `initialize` method for Application initializer 'raven' should take only one argument - `App`, an instance of an `Application`. [deprecation id: ember-application.app-initializer-initialize-arguments] See http://emberjs.com/deprecations/v2.x/#toc_initializer-arity for more details.
```