### PR TITLE
Using Ember.merge to avoid compatibility issues.

### DIFF
--- a/app/instance-initializers/raven-setup.js
+++ b/app/instance-initializers/raven-setup.js
@@ -29,7 +29,7 @@ export function initialize(application) {
     window.Raven.debug = debug;
 
     // Keeping existing config values for includePaths, whitelistUrls, for compatibility.
-    const ravenConfig = Object.assign({
+    const ravenConfig = Ember.merge({
       includePaths,
       whitelistUrls,
       release: service.get(serviceReleaseProperty) || config.APP.version


### PR DESCRIPTION
Hit a compatibility problems with Object.assign (most notable in some PhantomJS runs, and would see in pre-Edge IE).