### PR TITLE
switch to Ember.assign (Ember.merge deprecated)

### DIFF
--- a/app/instance-initializers/raven-setup.js
+++ b/app/instance-initializers/raven-setup.js
@@ -1,6 +1,10 @@
 import Ember from 'ember';
 import config from '../config/environment';
 
+// Ember merge is deprecated as of 2.5, but we need to check for backwards
+// compatibility.
+const assign = Ember.assign || Ember.merge;
+
 export function initialize(application) {
 
   if (Ember.get(config, 'sentry.development') === true) {
@@ -29,7 +33,7 @@ export function initialize(application) {
     window.Raven.debug = debug;
 
     // Keeping existing config values for includePaths, whitelistUrls, for compatibility.
-    const ravenConfig = Ember.merge({
+    const ravenConfig = assign({
       includePaths,
       whitelistUrls,
       release: service.get(serviceReleaseProperty) || config.APP.version


### PR DESCRIPTION
Ember.merge is deprecated in the current beta release, generating a warning when using this plugin.

See: https://github.com/emberjs/ember.js/pull/12303

This PR switches to using `Ember.assign` if available.

I used the same backwards compatible strategy that `ember-power-select` is using. See: https://github.com/cibernox/ember-power-select/pull/406

All tests pass for me locally.