### PR TITLE
Stay quiet unless debugging enabled.

### DIFF
--- a/app/instance-initializers/raven-setup.js
+++ b/app/instance-initializers/raven-setup.js
@@ -8,7 +8,9 @@ const assign = Ember.assign || Ember.merge;
 export function initialize(application) {
 
   if (Ember.get(config, 'sentry.development') === true) {
-    Ember.Logger.info('`sentry` is configured for development mode.');
+    if (Ember.get(config, 'sentry.debug') === true) {
+      Ember.Logger.info('`sentry` is configured for development mode.');
+    }
     return;
   }
 


### PR DESCRIPTION
That logger line was annoying some folks here, so would be nice to only emit it when debugging is enabled.