### PR TITLE
Update to raven.js 3.0.5 and expose captureBreadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # ember-cli-sentry changelog
 
+## TO BE RELEASED
+
+Note: Raven.js 3.0 introduces some potentially breaking changes. Please take a
+look at the [raven.js CHANGELOG](
+https://github.com/getsentry/raven-js/blob/master/CHANGELOG.md#300 )
+
+- Update raven.js to 3.0.5
+- Expose raven 3.x's `captureBreadcrumb` function
+
 ## 2.3.3
 
 - Removed a possibly annoying log [#37](https://github.com/damiencaselli/ember-cli-sentry/pull/47).

--- a/README.md
+++ b/README.md
@@ -20,9 +20,19 @@ This addon does **not**:
 * Generate the logging service for you.
 * Provide a Sentry key for testing.
 
-## Important notice if you migrate from 1.x.x to 2.x
+## Upgrading
 
-Please have a look at [this wiki entry](https://github.com/damiencaselli/ember-cli-sentry/wiki/Migration-from-1.x.x-to-2.x) if you upgrade major version of ember-cli-sentry.
+## 1.xxx -> 2.x.x | 3.x.x
+
+Please have a look at [this wiki
+entry](https://github.com/damiencaselli/ember-cli-sentry/wiki/Migration-from-1.x.x-to-2.x)
+if you upgrade major version of ember-cli-sentry.
+
+## 2.x.x -> 3.x.x
+
+Raven.js 3.0 introduces some potentially breaking changes. Please take a
+look at the [raven.js CHANGELOG](
+https://github.com/getsentry/raven-js/blob/master/CHANGELOG.md#300 )
 
 ## Install
 

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -80,6 +80,30 @@ let RavenService = Service.extend({
   },
 
   /**
+   *
+   * Tries to capture a breadcrumb.
+   *
+   * Sentry supports a concept called Breadcrumbs, which is a trail of events
+   * which happened prior to an issue.
+   *
+   * Often times these events are very similar to traditional logs, but also
+   * have the ability to record more rich structured data.
+   *
+   * @param {string} message A string describing the event. The most common vector, often used as a drop-in for a
+   *   traditional log message.
+   * @param {string} category A category to label the event under. This generally is similar to a logger name, and will
+   *   let you more easily understand the area an event took place, such as auth.
+   * @param {Object} data A mapping of metadata around the event. This is often used instead of message, but may also
+   *   be used in addition.
+   * @param {('error'|'warn'|'info'|'debug')} The level may be any of error, warn, info, or debug.
+   */
+  captureBreadcrumb(message, category, data, level) {
+    if (this.get('isRavenUsable')) {
+      window.Raven.captureBreadcrumb(...arguments);
+    }
+  },
+
+  /**
    * Binds functions to `Ember.onerror` and `Ember.RSVP.on('error')`.
    *
    * @method enableGlobalErrorCatching

--- a/blueprints/ember-cli-sentry/index.js
+++ b/blueprints/ember-cli-sentry/index.js
@@ -7,7 +7,7 @@ module.exports = {
 
   afterInstall: function() {
     return this.addBowerPackagesToProject([
-      { name: 'raven-js', target: '~2.2' }
+      { name: 'raven-js', target: '~3.0.5' }
     ]);
   }
 };

--- a/blueprints/logger/files/__root__/services/__name__.js
+++ b/blueprints/logger/files/__root__/services/__name__.js
@@ -12,6 +12,10 @@ export default RavenLogger.extend({
     return this._super(...arguments);
   },
 
+  captureBreadcrumb(/*message, category, data, level*/) {
+    return this._super(...arguments);
+  },
+
   enableGlobalErrorCatching() {
     return this._super(...arguments);
   },


### PR DESCRIPTION
Perhaps in the future we can provide more breadcrumb integration, such as logging route transitions for example.

But this commit just exposes the method and bumps the library.