### PR TITLE
Parse RegExp in ignoreErrors

### DIFF
--- a/addon/utils/parse-regex-errors.js
+++ b/addon/utils/parse-regex-errors.js
@@ -1,0 +1,17 @@
+export function parseRegexErrors(errors) {
+  if (!errors || errors.constructor !== Array) {
+    return [];
+  }
+
+  const regex = new RegExp(/^\/(.*)\/([gimuy]*)$/);
+  const regexGroups = { pattern: 1, flags: 2 };
+
+  return errors.map((error) => {
+    if (typeof error && regex.test(error)) {
+      let match = regex.exec(error);
+      return new RegExp(match[regexGroups.pattern], match[regexGroups.flags]);
+    }
+
+    return error;
+  });
+}

--- a/app/instance-initializers/raven-setup.js
+++ b/app/instance-initializers/raven-setup.js
@@ -5,6 +5,16 @@ import config from '../config/environment';
 // compatibility.
 const assign = Ember.assign || Ember.merge;
 
+const parseRegexErrors = function parseRegexErrors(ravenOptions) {
+  return Ember.get(ravenOptions, 'ignoreErrors').map((error) => {
+    if (error.startsWith('/') && error.endsWith('/')) {
+      return new RegExp(error.slice(1, error.length - 1));
+    }
+
+    return error;
+  });
+}
+
 export function initialize(application) {
 
   if (Ember.get(config, 'sentry.development') === true) {
@@ -28,6 +38,10 @@ export function initialize(application) {
     serviceReleaseProperty = 'release',
     ravenOptions = {}
   } = config.sentry;
+
+  if (Ember.get(ravenOptions, 'ignoreErrors.length')) {
+    Ember.set(ravenOptions, 'ignoreErrors', parseRegexErrors(ravenOptions));
+  }
 
   const lookupName = `service:${serviceName}`;
   const service = application.lookup(lookupName);

--- a/app/instance-initializers/raven-setup.js
+++ b/app/instance-initializers/raven-setup.js
@@ -1,19 +1,10 @@
 import Ember from 'ember';
 import config from '../config/environment';
+import { parseRegexErrors } from 'ember-cli-sentry/utils/parse-regex-errors';
 
 // Ember merge is deprecated as of 2.5, but we need to check for backwards
 // compatibility.
 const assign = Ember.assign || Ember.merge;
-
-const parseRegexErrors = function parseRegexErrors(ravenOptions) {
-  return Ember.get(ravenOptions, 'ignoreErrors').map((error) => {
-    if (error.startsWith('/') && error.endsWith('/')) {
-      return new RegExp(error.slice(1, error.length - 1));
-    }
-
-    return error;
-  });
-}
 
 export function initialize(application) {
 
@@ -40,7 +31,7 @@ export function initialize(application) {
   } = config.sentry;
 
   if (Ember.get(ravenOptions, 'ignoreErrors.length')) {
-    Ember.set(ravenOptions, 'ignoreErrors', parseRegexErrors(ravenOptions));
+    Ember.set(ravenOptions, 'ignoreErrors', parseRegexErrors(ravenOptions.ignoreErrors));
   }
 
   const lookupName = `service:${serviceName}`;

--- a/tests/unit/utils/parse-regex-errors-test.js
+++ b/tests/unit/utils/parse-regex-errors-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Helper | parseRegexErrors');
 
-test('it returns an empty', function(assert) {
+test('it returns an empty array', function(assert) {
   let result = parseRegexErrors([]);
 
   assert.equal(result.length, 0);
@@ -21,7 +21,7 @@ test('it returns an empty', function(assert) {
   assert.equal(result.length, 0);
 });
 
-test('it returns the same content if no RegExp were found in the array', function(assert) {
+test('it does not modify basic strings', function(assert) {
   let errors = [
     'Error Message 401',
     'Error Message 404',
@@ -33,7 +33,7 @@ test('it returns the same content if no RegExp were found in the array', functio
   assert.deepEqual(result[1], errors[1]);
 });
 
-test('it recognize RegExp stored as a string', function(assert) {
+test('it converts string RegExp into RegExp', function(assert) {
   let errors = [
     'Error Message 401',
     '/Error Message .*/',
@@ -46,7 +46,7 @@ test('it recognize RegExp stored as a string', function(assert) {
   assert.deepEqual(result[1], /Error Message .*/);
 });
 
-test('it allows modifiers', function(assert) {
+test('it preserves the RegExp flags', function(assert) {
   let errors = [
     '/Error Message .*/gi',
     '/Error Message .*/ig',
@@ -64,7 +64,7 @@ test('it allows modifiers', function(assert) {
   assert.deepEqual(result[4], new RegExp('Error Message .*', 'm'));
 });
 
-test('it throw an error when a RegExp is invalid', function(assert) {
+test('it throws an error when a RegExp is invalid', function(assert) {
   assert.throws(parseRegexErrors([
     '/Error Message .*/foo',
   ]));

--- a/tests/unit/utils/parse-regex-errors-test.js
+++ b/tests/unit/utils/parse-regex-errors-test.js
@@ -1,0 +1,71 @@
+import { parseRegexErrors } from 'ember-cli-sentry/utils/parse-regex-errors';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | parseRegexErrors');
+
+test('it returns an empty', function(assert) {
+  let result = parseRegexErrors([]);
+
+  assert.equal(result.length, 0);
+
+  result = parseRegexErrors({});
+
+  assert.equal(result.length, 0);
+
+  result = parseRegexErrors(null);
+
+  assert.equal(result.length, 0);
+
+  result = parseRegexErrors(undefined);
+
+  assert.equal(result.length, 0);
+});
+
+test('it returns the same content if no RegExp were found in the array', function(assert) {
+  let errors = [
+    'Error Message 401',
+    'Error Message 404',
+  ];
+
+  let result = parseRegexErrors(errors);
+
+  assert.deepEqual(result[0], errors[0]);
+  assert.deepEqual(result[1], errors[1]);
+});
+
+test('it recognize RegExp stored as a string', function(assert) {
+  let errors = [
+    'Error Message 401',
+    '/Error Message .*/',
+  ];
+
+  let result = parseRegexErrors(errors);
+
+  assert.deepEqual(result[0], errors[0]);
+  assert.notDeepEqual(result[1], errors[1]);
+  assert.deepEqual(result[1], /Error Message .*/);
+});
+
+test('it allows modifiers', function(assert) {
+  let errors = [
+    '/Error Message .*/gi',
+    '/Error Message .*/ig',
+    '/Error Message .*/g',
+    '/Error Message .*/i',
+    '/Error Message .*/m',
+  ];
+
+  let result = parseRegexErrors(errors);
+
+  assert.deepEqual(result[0], new RegExp('Error Message .*', 'gi'));
+  assert.deepEqual(result[1], new RegExp('Error Message .*', 'ig'));
+  assert.deepEqual(result[2], new RegExp('Error Message .*', 'g'));
+  assert.deepEqual(result[3], new RegExp('Error Message .*', 'i'));
+  assert.deepEqual(result[4], new RegExp('Error Message .*', 'm'));
+});
+
+test('it throw an error when a RegExp is invalid', function(assert) {
+  assert.throws(parseRegexErrors([
+    '/Error Message .*/foo',
+  ]));
+});


### PR DESCRIPTION
For the issue #49, it looks like the ember-cli team won't support this.

See https://github.com/ember-cli/ember-cli/issues/5954#issuecomment-223831128.

Do you mind considering this improvement?