### PR TITLE
Async load Sentry script

### DIFF
--- a/app/instance-initializers/raven-setup.js
+++ b/app/instance-initializers/raven-setup.js
@@ -1,6 +1,10 @@
 import Ember from 'ember';
 import config from '../config/environment';
 
+// Ember merge is deprecated as of 2.5, but we need to check for backwards
+// compatibility.
+const assign = Ember.assign || Ember.merge;
+
 export function initialize(application) {
 
   if (Ember.get(config, 'sentry.development') === true) {
@@ -29,7 +33,7 @@ export function initialize(application) {
     window.Raven.debug = debug;
 
     // Keeping existing config values for includePaths, whitelistUrls, for compatibility.
-    const ravenConfig = Ember.merge({
+    const ravenConfig = assign({
       includePaths,
       whitelistUrls,
       release: service.get(serviceReleaseProperty) || config.APP.version

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
 
   contentFor: function(type, config) {
     if (type === 'body-footer' && config.sentry && !config.sentry.development && config.sentry.cdn) {
-      return '<script src="' + config.sentry.cdn + '"></script>';
+      return '<script async="async" src="' + config.sentry.cdn + '"></script>';
     }
   }
 };


### PR DESCRIPTION
I mostly wanted to get your thoughts around this.

I know Sentry recommends not loading their library async, but oftentimes their CDN is super slow and slows down our pages.

Would you be opposed to something like this? What if it were behind a config flag defaulted to `false`?