### PR TITLE
In index.js, use ui.writeLine instead of console.log to respect --silent

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
         app.import(app.bowerDirectory + '/raven-js/dist/raven.js');
       }
     } catch (e) {
-      console.log('ember-cli-sentry will not be loaded from bower installation');
+      this.ui.writeLine('ember-cli-sentry will not be loaded from bower installation');
     }
   },
 


### PR DESCRIPTION
This change respects the `--silent` flag when building. I've confirmed this works locally. 

> Every addon is sent an instance of the parent application’s command line output stream. If you want to write out to the command line in your addon’s index.js file, you should use this.ui.writeLine rather than console.log. This will make the output obey the --silent flag available with many ember-cli commands.

from https://ember-cli.com/extending/#writing-to-the-command-line