### PR TITLE
Use caret instead of tilde semver, use 3.x for raven-js

### DIFF
--- a/blueprints/ember-cli-sentry/index.js
+++ b/blueprints/ember-cli-sentry/index.js
@@ -7,7 +7,7 @@ module.exports = {
 
   afterInstall: function() {
     return this.addBowerPackagesToProject([
-      { name: 'raven-js', target: '~3.3' }
+      { name: 'raven-js', target: '^3.3' }
     ]);
   }
 };


### PR DESCRIPTION
This allows 3.x instead of 3.3.x. The current version is 3.14.x and we are stuck on 3.3.x. All minor versions should be backwards compatible.