### PR TITLE
Load raven-js from NPM instead of Bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This addon does:
 * Enable safe use of Raven.js whether you are in development mode or not.
 * Inject a logging service to routes, components, controllers and models to access Raven object.
 * Provide a default logger generator that should work for the vast majority of people.
-* Add an **opt-out** bower dependency to ravenjs.
+* Add an **opt-out** NPM dependency to raven-js.
 * Provide rather complete customization.
 
 This addon does **not**:
@@ -28,8 +28,8 @@ Please have a look at [this wiki entry](https://github.com/damiencaselli/ember-c
 
 From any ember-cli application, run `ember install ember-cli-sentry`.
 
-_Note: Since **v2.1.2**, Raven bower component is automatically included by this addon.  
-If you want to use your own packaged version or the cdn option, you'll have to opt-out by removing it from bower dependencies._
+_Note: raven-js NPM package is automatically included by this addon.
+If you want to use your own packaged version or the cdn option, you'll have to opt-out by removing it from package.json dependencies._
 
 The addon will assume there is an available service that proxies Raven, which is not the case unless you already did the install.
 

--- a/blueprints/ember-cli-sentry/index.js
+++ b/blueprints/ember-cli-sentry/index.js
@@ -6,8 +6,6 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addBowerPackagesToProject([
-      { name: 'raven-js', target: '~3.3' }
-    ]);
+    return this.addPackageToProject('raven-js', '^3.0.0');
   }
 };

--- a/index.js
+++ b/index.js
@@ -2,24 +2,47 @@
 'use strict';
 
 var fs = require('fs');
+var path = require('path');
+var Funnel = require('broccoli-funnel');
+var MergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
   name: 'ember-cli-sentry',
 
-  included: function(app) {
-    this._super.included(app);
-
+  // Imports raven.js to vendor directory if installed via NPM
+  treeForVendor(vendorTree) {
     try {
-      var stats = fs.statSync(app.bowerDirectory + '/raven-js/dist/raven.js');
-      if (!stats.errno) {
-        app.import(app.bowerDirectory + '/raven-js/dist/raven.js');
-      }
+      var ravenPackage = require.resolve('raven-js');
+      var ravenTree = new Funnel(path.resolve(path.dirname(ravenPackage), '../dist'), {
+        files: ['raven.js']
+      });
+
+      return new MergeTrees([vendorTree, ravenTree]);
     } catch (e) {
-      this.ui.writeLine('ember-cli-sentry will not be loaded from bower installation');
+      return vendorTree;
     }
   },
 
-  contentFor: function(type, config) {
+  included(app) {
+    this._super.included.apply(this, arguments);
+
+    try {
+      var ravenPackage = require.resolve('raven-js'); // will trigger catch if NPM package is absent
+
+      app.import('vendor/raven.js');
+    } catch (e) {
+      try {
+        var stats = fs.statSync(app.bowerDirectory + '/raven-js/dist/raven.js');
+        if (!stats.errno) {
+          app.import(app.bowerDirectory + '/raven-js/dist/raven.js');
+        }
+      } catch (e) {
+        this.ui.writeLine('raven-js will not be loaded from NPM or Bower installation');
+      }
+    }
+  },
+
+  contentFor(type, config) {
     if (type === 'body-footer' && config.sentry && !config.sentry.development && config.sentry.cdn) {
       return '<script src="' + config.sentry.cdn + '"></script>';
     }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "raven"
   ],
   "dependencies": {
+    "broccoli-funnel": "^1.2.0",
+    "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {


### PR DESCRIPTION
Since ember-cli 2.11 made Bower optional and ember-cli 2.13 has removed Bower completely from new projects, this PR leverages the fact that raven-js is available via NPM.

- The default blueprint will add raven-js as an NPM package instead of a Bower package.
- To avoid breaking changes for existing users, `index.js` will look for the NPM package first, fall back to the Bower package second, and then rely on CDN configuration third.