### PR TITLE
CI: Publish tags automatically to npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,10 @@ script:
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
 
+before_deploy:
+  - yarn global add auto-dist-tag
+  - auto-dist-tag --write
+
 deploy:
   provider: npm
   email: info@simplabs.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,12 @@ script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
+
+deploy:
+  provider: npm
+  email: info@simplabs.com
+  api_key:
+    secure: BkvjZ5VYVEF7JHlitiA9TVZGfYdNTLohV5C/ZtMjb4ylIlXH9VftjyTbKybfUpodfK13Qr/Oif/xVd8yKxyZl0R+kmB94pMm89J+q4jl2WB0lOJ5Qk4iXMOd5tIZTiLyIvggkVDf7y+YBIFFmbPxozJgOVG2DRXsYezafDuL4sg=
+  on:
+    tags: true
+    repo: damiencaselli/ember-cli-sentry


### PR DESCRIPTION
Example release instructions from now on:

```
npm version minor
git push origin master --follow-tags
```

