### PR TITLE
Add a captureBreadcrumb method

### DIFF
--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -173,7 +173,7 @@ export default Service.extend({
     if (this.get('isRavenUsable')) {
       Raven.captureBreadcrumb(crumb);
     } else {
-      Ember.info(crumb);
+      Ember.debug(crumb);
     }
     return true;
   },

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -169,7 +169,7 @@ export default Service.extend({
     if (this.get('isRavenUsable')) {
       Raven.captureBreadcrumb(crumb);
     } else {
-      Ember.debug(crumb.message || crumb);
+      Ember.debug(Ember.inspect(crumb));
     }
     return true;
   },

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -162,14 +162,18 @@ export default Service.extend({
    * when any call to captureMessage or captureException is made.
    *
    * @method captureBreadcrumb
-   * @param  {String} message The message to capture
+   * @param  {String} or {object} crumb The message or object to capture
    * @return {Boolean}
    */
-  captureBreadcrumb(message) {
+  captureBreadcrumb(crumb) {
+    if (typeOf(crumb) === 'string'){
+      crumb = {message: crumb}
+    }
+    
     if (this.get('isRavenUsable')) {
-      Raven.captureBreadcrumb(...arguments);
+      Raven.captureBreadcrumb(crumb);
     } else {
-      Ember.info(message);
+      Ember.info(crumb);
     }
     return true;
   },

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -162,14 +162,10 @@ export default Service.extend({
    * when any call to captureMessage or captureException is made.
    *
    * @method captureBreadcrumb
-   * @param  {String} or {object} crumb The message or object to capture
+   * @param  {object} crumb The object representing the breadcrumb to capture
    * @return {Boolean}
    */
   captureBreadcrumb(crumb) {
-    if (typeOf(crumb) === 'string'){
-      crumb = {message: crumb}
-    }
-    
     if (this.get('isRavenUsable')) {
       Raven.captureBreadcrumb(crumb);
     } else {

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -173,7 +173,7 @@ export default Service.extend({
     if (this.get('isRavenUsable')) {
       Raven.captureBreadcrumb(crumb);
     } else {
-      Ember.debug(crumb);
+      Ember.debug(crumb.message || crumb);
     }
     return true;
   },

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -156,6 +156,23 @@ export default Service.extend({
     }
     return true;
   },
+  
+  /**
+   * Adds a message to the Raven breadcrumb trail, which will be sent
+   * when any call to captureMessage or captureException is made.
+   *
+   * @method captureBreadcrumb
+   * @param  {String} message The message to capture
+   * @return {Boolean}
+   */
+  captureBreadcrumb(message) {
+    if (this.get('isRavenUsable')) {
+      Raven.captureBreadcrumb(...arguments);
+    } else {
+      Ember.debug(message);
+    }
+    return true;
+  },
 
   /**
    * Binds functions to `Ember.onerror` and `Ember.RSVP.on('error')`.

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -169,7 +169,7 @@ export default Service.extend({
     if (this.get('isRavenUsable')) {
       Raven.captureBreadcrumb(...arguments);
     } else {
-      Ember.debug(message);
+      Ember.info(message);
     }
     return true;
   },

--- a/tests/dummy/app/components/x-button.js
+++ b/tests/dummy/app/components/x-button.js
@@ -7,6 +7,7 @@ export default Component.extend({
   tagName: 'button',
 
   click() {
+    this.get('raven').captureBreadcrumb('Breadcrumb captured from test component');
     this.get('raven').captureMessage('Message captured from test component');
     this.get('raven').captureException(new Error('Message captured from test component'));
 

--- a/tests/dummy/app/components/x-button.js
+++ b/tests/dummy/app/components/x-button.js
@@ -7,7 +7,7 @@ export default Component.extend({
   tagName: 'button',
 
   click() {
-    this.get('raven').captureBreadcrumb('Breadcrumb captured from test component');
+    this.get('raven').captureBreadcrumb({message: 'Breadcrumb captured from test component'});
     this.get('raven').captureMessage('Message captured from test component');
     this.get('raven').captureException(new Error('Message captured from test component'));
 

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -6,6 +6,7 @@ export default Controller.extend({
 
   actions: {
     captureSomething(something) {
+      this.get('raven').captureBreadcrumb('Breadcrumb captured from ApplicationController');
       this.get('raven').captureMessage(`"${something}" captured from ApplicationController`);
       this.get('raven').captureException(new Error('Exception captured from ApplicationController'));
     },

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -6,7 +6,7 @@ export default Controller.extend({
 
   actions: {
     captureSomething(something) {
-      this.get('raven').captureBreadcrumb('Breadcrumb captured from ApplicationController');
+      this.get('raven').captureBreadcrumb({message: 'Breadcrumb captured from ApplicationController'});
       this.get('raven').captureMessage(`"${something}" captured from ApplicationController`);
       this.get('raven').captureException(new Error('Exception captured from ApplicationController'));
     },

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -6,7 +6,7 @@ export default Route.extend({
 
   captureMessageOnActivate: on('activate', function() {
     this.get('raven').callRaven('setUserContext', { id: 'abc12345', name: 'The mighty tester' });
-    this.get('raven').captureBreadcrumb('Breadcrumb captured from ApplicationRoute');
+    this.get('raven').captureBreadcrumb({message: 'Breadcrumb captured from ApplicationRoute'});
     this.get('raven').captureMessage('Message captured from ApplicationRoute');
     this.get('raven').captureException(new Error('Exception captured from ApplicationRoute'));
   })

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -6,6 +6,7 @@ export default Route.extend({
 
   captureMessageOnActivate: on('activate', function() {
     this.get('raven').callRaven('setUserContext', { id: 'abc12345', name: 'The mighty tester' });
+    this.get('raven').captureBreadcrumb('Breadcrumb captured from ApplicationRoute');
     this.get('raven').captureMessage('Message captured from ApplicationRoute');
     this.get('raven').captureException(new Error('Exception captured from ApplicationRoute'));
   })


### PR DESCRIPTION
captureBreadcrumb is great to use instead of `Ember.debug`. In production these messages are sent when any call to `captureMessage` or `captureException` is made and provides valuable context.