### PR TITLE
Update ember-cli-node-assets and use correct .import

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,12 +13,9 @@ module.exports = {
   },
 
   included: function(app) {
-    // see: https://github.com/ember-cli/ember-cli/issues/3718
-    if (typeof app.import !== 'function' && app.app) {
-      app = app.app;
-    }
+    var importer = this.import ? this : findHost(this);    
 
-    app.import('vendor/raven-shim.js', {
+    importer.import('vendor/raven-shim.js', {
       type: 'vendor',
       exports: { 'raven': ['default'] }
     });
@@ -26,3 +23,14 @@ module.exports = {
     this._super.included.apply(this, arguments);
   }
 };
+
+function findHost(addon) {
+  var current = addon;
+  var app;
+
+  do {
+    app = current.app || app;
+  } while (current.parent.parent && (current = current.parent));
+
+  return app;
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.1.0",
-    "ember-cli-node-assets": "^0.1.6",
+    "ember-cli-node-assets": "^0.2.2",
     "raven-js": "^3.15.0"
   },
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,10 +1269,6 @@ broccoli-uglify-sourcemap@^1.0.0:
     uglify-js "^2.7.0"
     walk-sync "^0.1.3"
 
-broccoli-unwatched-tree@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-unwatched-tree/-/broccoli-unwatched-tree-0.1.1.tgz#4312fde04bdafe67a05a967d72cc50b184a9f514"
-
 browserslist@^1.4.0:
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
@@ -1921,13 +1917,13 @@ ember-cli-lodash-subset@^1.0.11, ember-cli-lodash-subset@^1.0.7:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.11.tgz#0149eef9c0c3505ba44ed202f8d034ddbbfb2826"
 
-ember-cli-node-assets@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/ember-cli-node-assets/-/ember-cli-node-assets-0.1.6.tgz#6488a2949048c801ad6d9e33753c7bce32fc1146"
+ember-cli-node-assets@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-node-assets/-/ember-cli-node-assets-0.2.2.tgz#d2d55626e7cc6619f882d7fe55751f9266022708"
   dependencies:
     broccoli-funnel "^1.0.1"
     broccoli-merge-trees "^1.1.1"
-    broccoli-unwatched-tree "^0.1.1"
+    broccoli-source "^1.1.0"
     debug "^2.2.0"
     lodash "^4.5.1"
     resolve "^1.1.7"


### PR DESCRIPTION
This PR fixes nested addon import behavior. Starting from ember-cli 2.7, there is `this.import` that does the correct root app detection, so we can check if it exists, before 2.7 there is a polyfill, which is `findHost` in this PR.

This is the way, how nesting fails:

```
App <-- at this level, include of the addon wasn't happening
  -- Included addon
      -- has dependency on ember-cli-sentry
```

I've kinda backported changes from ember-cli-node-assets:
https://github.com/dfreeman/ember-cli-node-assets/blob/master/index.js
