### PR TITLE
Check for Fastboot in isRavenUsable

### DIFF
--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -68,7 +68,7 @@ export default Service.extend({
    * @type Ember.ComputedProperty
    */
   isRavenUsable: computed(function() {
-    return Raven.isSetup() === true;
+    return typeof(FastBoot) === 'undefined' && Raven.isSetup() === true;
   }).volatile(),
 
   /**

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "ember-cli-babel": "^6.1.0",
     "ember-cli-node-assets": "^0.1.6",
-    "raven-js": "^3.15.0"
+    "raven-js": "github:getsentry/raven-js"
   },
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "ember-cli-babel": "^6.1.0",
     "ember-cli-node-assets": "^0.1.6",
-    "raven-js": "github:getsentry/raven-js"
+    "raven-js": "^3.15.0"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
While this does NOT fix the sentry running in FastBoot issue, is does stop raven from causing the Fastboot server to crash whenever an error takes place.

raven-js depends on XMLHTTPRequest to send reports to Sentry, unfortunatley, in fastboot that's not available and the result is a irrecoverable crash for the server.  There's an official patch upstream in raven-js for this, but they seem pretty slow to release versions so this handles it in the meantime.

Ideally, we'll get back to looking at versions that support both raven-node and raven-js for true fastboot support 👍 

See also https://github.com/damiencaselli/ember-cli-sentry/issues/77