### PR TITLE
Do not throw error/message when raven disabled

### DIFF
--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -129,8 +129,6 @@ export default Service.extend({
   captureException(error) {
     if (this.get('isRavenUsable')) {
       Raven.captureException(...arguments);
-    } else {
-      throw error;
     }
   },
 
@@ -145,7 +143,7 @@ export default Service.extend({
     if (this.get('isRavenUsable')) {
       Raven.captureMessage(...arguments);
     } else {
-      throw new Error(message);
+      Ember.Logger.debug(message);
     }
     return true;
   },

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -130,9 +130,7 @@ export default Service.extend({
     if (this.get('isRavenUsable')) {
       Raven.captureException(...arguments);
     } else {
-      /* eslint-disable no-console */
       console.error(error);
-      /* eslint-enable no-console */
     }
   },
 
@@ -147,9 +145,7 @@ export default Service.extend({
     if (this.get('isRavenUsable')) {
       Raven.captureMessage(...arguments);
     } else {
-      /* eslint-disable no-console */
       console.info(message);
-      /* eslint-enable no-console */
     }
     return true;
   },

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -129,6 +129,10 @@ export default Service.extend({
   captureException(error) {
     if (this.get('isRavenUsable')) {
       Raven.captureException(...arguments);
+    } else {
+      /* eslint-disable no-console */
+      console.error(error);
+      /* eslint-enable no-console */
     }
   },
 
@@ -143,7 +147,9 @@ export default Service.extend({
     if (this.get('isRavenUsable')) {
       Raven.captureMessage(...arguments);
     } else {
-      Ember.Logger.debug(message);
+      /* eslint-disable no-console */
+      console.info(message);
+      /* eslint-enable no-console */
     }
     return true;
   },


### PR DESCRIPTION
Currently when `captureException` or `captureMessage` on the raven service are used while Raven is not configured (development and test), it throws the exception or message.

This is not the behavior of [ravenjs](https://docs.sentry.io/clients/javascript/usage/) when it has not been configured and certainly doesn't seem like correct behavior for this package. It makes it impossible to write tests around behavior that reports messages or exceptions to Sentry.