### PR TITLE
Remove bad default error message

### DIFF
--- a/blueprints/logger/files/__root__/services/__name__.js
+++ b/blueprints/logger/files/__root__/services/__name__.js
@@ -1,9 +1,6 @@
 import RavenLogger from 'ember-cli-sentry/services/raven';
 
 export default RavenLogger.extend({
-
-  unhandledPromiseErrorMessage: '',
-
   captureException(/* error */) {
     this._super(...arguments);
   },


### PR DESCRIPTION
The blueprint for the raven service contains a blank string as the default promise error message. This doesn't seem to make any sense, since [the inherited value](https://github.com/damiencaselli/ember-cli-sentry/blob/master/addon/services/raven.js#L44) would work just fine.