### PR TITLE
Fix Ember.Logger deprecation

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import { get } from '@ember/object';
 
 import Raven from 'raven';
@@ -10,7 +9,7 @@ export function initialize(container, config) {
 
   if (get(config, 'sentry.development') === true) {
     if (get(config, 'sentry.debug') === true) {
-      Ember.Logger.info('`sentry` is configured for development mode.');
+      console.info('`sentry` is configured for development mode.'); // eslint-disable-line no-console
     }
     return;
   }

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/avoid-leaking-state-in-ember-objects */
-
 import Ember from 'ember';
 import { assign as _assign, merge } from '@ember/polyfills';
 import Service from '@ember/service';
@@ -50,7 +48,9 @@ export default Service.extend({
    * @property ignoreErrors
    * @type Array
    */
-  ignoreErrors: [],
+  ignoreErrors: computed(function() {
+    return [];
+  }),
 
   /**
    * Ignore errors if any of the stack trace file paths matches any string or regex in this list.
@@ -58,7 +58,9 @@ export default Service.extend({
    * @property ignoreUrls
    * @type Array
    */
-  ignoreUrls: [],
+  ignoreUrls: computed(function() {
+    return [];
+  }),
 
   /**
    * Utility function used internally to check if Raven object

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -106,7 +106,7 @@ export default Service.extend({
 
       Raven.config(dsn, ravenConfig);
     } catch (e) {
-      Ember.Logger.warn('Error during `sentry` initialization: ' + e);
+      console.warn('Error during `sentry` initialization: ' + e); // eslint-disable-line no-console
       return;
     }
 
@@ -160,7 +160,7 @@ export default Service.extend({
     if (this.get('isRavenUsable')) {
       Raven.captureBreadcrumb(...arguments);
     } else {
-      Ember.Logger.info(breadcrumb);
+      console.info(breadcrumb); // eslint-disable-line no-console
     }
   },
 


### PR DESCRIPTION
Replace Ember.Logger with console to fix deprecation warnings.

Fixes #134 