### PR TITLE
Mark raven-shim as an ES module

### DIFF
--- a/vendor/raven-shim.js
+++ b/vendor/raven-shim.js
@@ -1,7 +1,9 @@
-define('raven', [], function() {
+define('raven', ['exports'], function(exports) {
   "use strict";
 
-  var Raven = window.Raven.noConflict();
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
 
-  return { 'default': Raven };
+  exports.default = window.Raven.noConflict();
 });


### PR DESCRIPTION
Ember's AMD loader is tolerant if you don't do this, but other build systems are not. I'm experimenting with getting a large number of addons compatible with other build tools (like Webpack and Parcel). In my testing this bug came up.

The bug is that consumers can't tell whether it's already a module that has a default export vs some random object that needs to get wrapped in another `{ default: ... }` to make it compatibility with consuming modules.