### PR TITLE
Use console rather than Ember.Logger

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     browser: true
   },
   rules: {
+    'no-console': 'off'
   },
   overrides: [
     // node files

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import { get } from '@ember/object';
 
 import Raven from 'raven';
@@ -10,7 +9,7 @@ export function initialize(container, config) {
 
   if (get(config, 'sentry.development') === true) {
     if (get(config, 'sentry.debug') === true) {
-      Ember.Logger.info('`sentry` is configured for development mode.');
+      console.info('`sentry` is configured for development mode.');
     }
     return;
   }

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -106,7 +106,7 @@ export default Service.extend({
 
       Raven.config(dsn, ravenConfig);
     } catch (e) {
-      Ember.Logger.warn('Error during `sentry` initialization: ' + e);
+      console.warn('Error during `sentry` initialization: ' + e);
       return;
     }
 
@@ -160,7 +160,7 @@ export default Service.extend({
     if (this.get('isRavenUsable')) {
       Raven.captureBreadcrumb(...arguments);
     } else {
-      Ember.Logger.info(breadcrumb);
+      console.info(breadcrumb);
     }
   },
 


### PR DESCRIPTION
The use of Ember.Logger was added to deprecations in ember 3.2. This
commit replaces any Ember.Logger calls with console.

ESlint rules were updated to avoid tests to fail.

This should fix #134.

Thsi PR contains changes that were requested in https://github.com/damiencaselli/ember-cli-sentry/pull/135#discussion_r216935884 by @Turbo87.