### PR TITLE
Drop node v4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "raven"
   ],
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Travis tests are currently running on node v4.
However, some dependencies require `node >=6`, resulting in travis tests failing.

To solve this, I bumped travis node version to 6 and updated `package.json` accordingly. I doubt there are many node 4 users around any more.