### PR TITLE
Update `raven-js` to v3.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^6.6.0",
-    "raven-js": "^3.15.0",
+    "raven-js": "^3.27.0",
     "resolve": "^1.5.0"
   },
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6204,10 +6204,10 @@ range-parser@~1.2.0:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
   integrity sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=
 
-raven-js@^3.15.0:
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.15.0.tgz#ebf95466b7d40fbbc3d6a5085af7c1431607926c"
-  integrity sha1-6/lUZrfUD7vD1qUIWvfBQxYHkmw=
+raven-js@^3.27.0:
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.27.0.tgz#9f47c03e17933ce756e189f3669d49c441c1ba6e"
+  integrity sha512-vChdOL+yzecfnGA+B5EhEZkJ3kY3KlMzxEhShKh6Vdtooyl0yZfYNFQfYzgMf2v4pyQa+OTZ5esTxxgOOZDHqw==
 
 raw-body@~1.1.0:
   version "1.1.7"


### PR DESCRIPTION
This updates us to the latest release before Sentry introduced their new JavaScript SDK.